### PR TITLE
chore(dev-release): 1.0.0-dev-1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samk-dev/astratto-ui",
-  "version": "1.0.0-dev",
+  "version": "1.0.0-dev-1",
   "description": "Yes, yet another UI library. Built on top of UIkit 3, it's exclusive to Nuxt",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
- fix vue prop types extend from external interfaces
- package.json version bump